### PR TITLE
Add multivariate statisticals

### DIFF
--- a/mibipret/analysis/reduction/__init__.py
+++ b/mibipret/analysis/reduction/__init__.py
@@ -1,0 +1,3 @@
+"""mibipret module for data analysis reducing sample data."""
+
+

--- a/mibipret/analysis/reduction/ordination.py
+++ b/mibipret/analysis/reduction/ordination.py
@@ -1,151 +1,393 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-Created on Tue Jul 16 13:59:36 2024
+"""Routines for performing ordination statistics on sample data.
 
-@author: alraune
+@author: Alraune Zech, Jorrit Bakker
 """
 
 import numpy as np
 import pandas as pd
+import skbio.stats.ordination as sciord
 from sklearn import decomposition
-# import skbio.stats.ordination as sciord
-
 from mibipret.data.names import name_sample
 
-def pca(data, 
-        select_columns = False,
+
+def pca(data_frame,
+        independent_variables = False,
+        dependent_variables = False,
         n_comp = 2,
         verbose = False,
         ):
+    """Function that performs Principal Component Analysis.
 
-    '''
-    Function that performs Principal Component Analysis.
-    
-    Makes use of routine sklearn.decomposition.PCA on the input data and gives 
+    Makes use of routine sklearn.decomposition.PCA on the input data and gives
     the site scores and loadings.
-    
-    Principal component analysis (PCA) is a linear dimensionality reduction 
-    technique with applications in exploratory data analysis, visualization 
-    and data preprocessing. The data is linearly transformed onto a new 
-    coordinate system such that the directions (principal components) capturing 
-    the largest variation in the data can be easily identified. 
 
-    Parameters
-    ----------
-        data : pd.dataframe
-            Tabular data containing quantities to be evaluated with standard
+    Principal component analysis (PCA) is a linear dimensionality reduction
+    technique with applications in exploratory data analysis, visualization
+    and data preprocessing. The data is linearly transformed onto a new
+    coordinate system such that the directions (principal components) capturing
+    the largest variation in the data can be easily identified.
+
+    Input
+    -----
+        data_frame : pd.dataframe
+            Tabular data containing variables to be evaluated with standard
             column names and rows of sample data.
+        independent_variables : Boolean or list of strings; default False
+            list with column names to select from data_frame
+            being characterized as independent variables (= environment)
+        dependent_variables : Boolean or list of strings; default is False
+            list with column names to select from data_frame
+            being characterized as dependent variables (= species)
         n_comp : int, default is 2
             Number of components to report
-        select_columns: Boolean or list of strings; default False
-           list with column names to select from dataframe for analysis             
         verbose : Boolean, The default is False.
-           Set to True to get messages in the Console about the status of the run code. 
+           Set to True to get messages in the Console about the status of the run code.
 
-    Returns
-    -------
+    Output
+    ------
         results : Dictionary
-            containing the scores and loadings of the PCA, 
-            the percentage of the variation explained by the first principal components
-            and the correlation coefficient between the first two PCs
-    '''
-
+            containing the scores and loadings of the PCA,
+            the percentage of the variation explained by the first principal components,
+            the correlation coefficient between the first two PCs,
+            names of columns (same length as loadings)
+            names of indices (same length as scores)
+    """
     if verbose:
         print('==============================================================')
         print(" Running function 'pca()' on data")
         print('==============================================================')
 
-    cols= check_data(data)       
-    data_pca = data.copy()
-    
-    if name_sample in cols:
-        data_pca.set_index(name_sample,inplace = True)
-        cols.remove(name_sample)
-    
-    if isinstance(select_columns,list):
-        intersection = list(set(cols) & set(select_columns))
-        remainder = list(set(select_columns) - set(cols))
-        if len(intersection) == 0:
-            raise ValueError("No specified column names identified in data.")     
-        elif len(intersection) < len(select_columns):
-            print("WARNING: not all specified column names are found in data.")
-            print('----------------------------------------------------------------')
-            print("Columns used in analysis:", intersection)
-            print("Column names not identified in data:", remainder)
-            print('________________________________________________________________')
+    data,cols= check_data_frame(data_frame)
 
-        # data_pca = data_pca.get(intersection)
-        data_pca = data_pca[intersection]
+    if independent_variables is False and dependent_variables is False:
+        data_pca = data
+        names_independent = cols
+        names_dependent = []
 
-    # heads = data_pca.columns.to_list()
-    # wells = list(data_pca.index)
-    
+    elif independent_variables is not False and dependent_variables is False:
+        names_independent = extract_variables(cols,
+                              independent_variables,
+                              name_variables = 'independent variables'
+                              )
+        names_dependent = []
+        data_pca = data[names_independent]
+    elif independent_variables is False and dependent_variables is not False:
+        names_dependent = extract_variables(cols,
+                              dependent_variables,
+                              name_variables = 'dependent variables'
+                              )
+        names_independent = []
+        data_pca = data[names_dependent]
+
+    else:
+        names_independent = extract_variables(cols,
+                              independent_variables,
+                              name_variables = 'independent variables'
+                              )
+        names_dependent = extract_variables(cols,
+                              dependent_variables,
+                              name_variables = 'dependent variables'
+                              )
+        data_pca = data[names_independent + names_dependent]
+
     # Checking if the dimensions of the dataframe allow for PCA
     if data_pca.shape[0] < data_pca.shape[1]:
-        raise Exception("PCA not possible with more variables than samples.")
+        raise ValueError("PCA not possible with more variables than samples.")
 
     try:
-        # Using scikit.decomposoition.PCA with an amount of components equal to the amount of variables, then getting the loadings, scores and explained variance ratio.
-        pca = decomposition.PCA(n_components=len(data_pca.columns)) 
+        # Using scikit.decomposoition.PCA with an amount of components equal
+        # to the amount of variables, then getting the loadings, scores and explained variance ratio.
+        pca = decomposition.PCA(n_components=len(data_pca.columns))
         pca.fit(data_pca)
         loadings = pca.components_.T
         PCAscores = pca.transform(data_pca)
         variances = pca.explained_variance_ratio_
-    except(ValueError):
-        raise ValueError("Not all column values are numeric values. Consider standardizing data first.")
-    
+    except(ValueError,TypeError):
+        raise TypeError("Not all column values are numeric values (or NaN). Consider standardizing data first.")
+
     # Taking the first two PC for plotting
-    loadings = loadings[:, 0:n_comp]
+    if dependent_variables is False:
+        loadings_independent = loadings[:, 0:n_comp]
+        loadings_dependent = np.array([[],[]]).T
+    else:
+        loadings_independent = loadings[:-len(names_dependent), 0:n_comp]
+        loadings_dependent = loadings[-len(names_dependent):, 0:n_comp]
     scores = PCAscores[:, 0:n_comp]
     percent_explained = np.around(100*variances/np.sum(variances), decimals=2)
     coef = np.corrcoef(scores[:,0], scores[:,1])[0,1]
-    
+
     if verbose:
-        print("Information about the succes of the PCA:")
-        print('----------------------------------------------------------------')        
+        print("Information about the success of the PCA:")
+        print('----------------------------------------------------------------')
         for i in range(len(percent_explained)):
-            print('Principle component {} explains {} \% of the total variance.'.format(i,percent_explained[i]))
+            print('Principle component {} explains {}% of the total variance.'.format(i,percent_explained[i]))
         print('\nThe correlation coefficient between PC1 and PC2 is {}.'.format(coef))
         print('----------------------------------------------------------------')
-    
+
     results = {"method": 'pca',
-               "loadings": loadings, 
-               "scores": scores, 
+               "loadings_dependent": loadings_dependent,
+               "loadings_independent": loadings_independent,
+               "names_independent" : names_independent,
+               "names_dependent" : names_dependent,
+               "scores": scores,
+               "sample_index" : list(data_pca.index),
                "percent_explained": percent_explained,
                "corr_PC1_PC2": coef,
                }
 
-    # if sample_names is True:
-    #     names = data[name_sample]
-
-    # sample_names = False,
-    # heads = data_pca.columns.to_list()
-    # wells = list(data_pca.index)
-    # names = {"heads": heads, "Species_head": Species_head, "Environment_head": Environment_head, "wells": wells}
-    
     return results
 
-def check_data(data):
+def cca(data_frame,
+        independent_variables,
+        dependent_variables,
+        n_comp = 2,
+        verbose = False,
+        ):
+    """Function that performs Canonical Correspondence Analysis.
+
+    Function makes use of skbio.stats.ordination.CCA on the input data and gives
+    the site scores and loadings.
+
+    Input
+    -----
+        data_frame : pd.dataframe
+            Tabular data containing variables to be evaluated with standard
+            column names and rows of sample data.
+        independent_variables : list of strings
+            list with column names data to be the independent variables (=environment)
+        dependent_variables : list of strings
+            list with column names data to be the dependen variables (=species)
+        n_comp : int, default is 2
+            number of dimensions to return
+        verbose : Boolean, The default is False.
+            Set to True to get messages in the Console about the status of the run code.
+
+    Output
+    ------
+        results : Dictionary
+            * method: name of ordination method (str)
+            * loadings_independent: loadings of independent variables (np.ndarray)
+            * loadings_dependent: loadings of dependent variables (np.ndarray)
+            * names_independent: names of independent varialbes (list of str)
+            * names_dependent: names of dependent varialbes (list of str)
+            * scores: scores (np.ndarray)
+            * sample_index: names of samples (list of str)
+    """
+    if verbose:
+        print('==============================================================')
+        print(" Running function 'cca()' on data")
+        print('==============================================================')
+
+    results = constrained_ordination(data_frame,
+                           independent_variables,
+                           dependent_variables,
+                           method = 'cca',
+                           n_comp = n_comp,
+                           )
+    return results
+
+def rda(data_frame,
+        independent_variables,
+        dependent_variables,
+        n_comp = 2,
+        verbose = False,
+        ):
+    """Function that performs Redundancy Analysis.
+
+    Function makes use of skbio.stats.ordination.RDA on the input data and gives
+    the site scores and loadings.
+
+    Input
+    -----
+        data_frame : pd.dataframe
+            Tabular data containing variables to be evaluated with standard
+            column names and rows of sample data.
+        independent_variables : list of strings
+            list with column names data to be the independent variables (=envirnoment)
+        dependent_variables : list of strings
+            list with column names data to be the dependent variables (=species)
+        n_comp : int, default is 2
+            number of dimensions to return
+        verbose : Boolean, The default is False.
+            Set to True to get messages in the Console about the status of the run code.
+
+    Output
+    ------
+        results : Dictionary
+            * method: name of ordination method (str)
+            * loadings_independent: loadings of independent variables (np.ndarray)
+            * loadings_dependent: loadings of dependent variables (np.ndarray)
+            * names_independent: names of independent varialbes (list of str)
+            * names_dependent: names of dependent varialbes (list of str)
+            * scores: scores (np.ndarray)
+            * sample_index: names of samples (list of str)
+    """
+    if verbose:
+        print('==============================================================')
+        print(" Running function 'rda()' on data")
+        print('==============================================================')
+
+    results = constrained_ordination(data_frame,
+                           independent_variables,
+                           dependent_variables,
+                           method = 'rda',
+                           n_comp = n_comp,
+                           )
+    return results
+
+
+def constrained_ordination(data_frame,
+                           independent_variables,
+                           dependent_variables,
+                           method = 'cca',
+                           n_comp = 2,
+        ):
+    """Function that performs constrained ordination.
+
+    Function makes use of skbio.stats.ordination on the input data and gives
+    the scores and loadings.
+
+    Input
+    -----
+        data_frame : pd.DataFrame
+            Tabular data containing variables to be evaluated with standard
+            column names and rows of sample data.
+        independent_variables : list of strings
+           list with column names data to be the independent variables (=environment)
+        dependent_variables : list of strings
+           list with column names data to be the dependen variables (=species)
+        method : string, default is cca
+            specification of ordination method of choice. Options 'cca' & 'rda'
+        n_comp : int, default is 2
+            number of dimensions to return
+
+    Output
+    ------
+        results : Dictionary
+            * method: name of ordination method (str)
+            * loadings_independent: loadings of independent variables (np.ndarray)
+            * loadings_dependent: loadings of dependent variables (np.ndarray)
+            * names_independent: names of independent varialbes (list of str)
+            * names_dependent: names of dependent varialbes (list of str)
+            * scores: scores (np.ndarray)
+            * sample_index: names of samples (list of str)
+    """
+    data,cols= check_data_frame(data_frame)
+
+    intersection = extract_variables(cols,
+                          independent_variables,
+                          name_variables = 'independent variables'
+                          )
+    data_independent_variables = data[intersection]
+
+    intersection = extract_variables(cols,
+                          dependent_variables,
+                          name_variables = 'dependent variables'
+                          )
+    data_dependent_variables = data[intersection]
+
+    # Checking if the dimensions of the dataframe allow for CCA
+    if (data_dependent_variables.shape[0] < data_dependent_variables.shape[1]) or \
+        (data_independent_variables.shape[0] < data_independent_variables.shape[1]):
+        raise ValueError("Ordination method {} not possible with more variables than samples.".format(method))
+
+    try:
+        # Performing constrained ordination using function from scikit-bio.
+        if method == 'cca':
+            sci_ordination = sciord.cca(data_dependent_variables, data_independent_variables, scaling = n_comp)
+        elif method == 'rda':
+            sci_ordination = sciord.rda(data_dependent_variables, data_independent_variables, scaling = n_comp)
+        else:
+            raise ValueError("Ordination method {} not a valid option.".format(method))
+
+        loadings_independent = sci_ordination.biplot_scores.to_numpy()[:,0:n_comp]
+        loadings_dependent = sci_ordination.features.to_numpy()[:,0:n_comp]
+        scores = sci_ordination.samples.to_numpy()[:,0:n_comp]
+
+    except(TypeError):
+        raise TypeError("Not all column values are numeric values. Consider standardizing data first.")
+
+    if loadings_independent.shape[1]<n_comp:
+        raise ValueError("Number of dependent variables too small.")
+
+    results = {"method": method,
+               "loadings_dependent": loadings_dependent,
+               "loadings_independent": loadings_independent,
+               "names_independent" : data_independent_variables.columns.to_list(),
+               "names_dependent" : data_dependent_variables.columns.to_list(),
+               "scores": scores,
+               "sample_index" : list(data.index),
+               }
+
+    return results
+
+def extract_variables(columns,
+                      variables,
+                      name_variables = 'variables'
+                      ):
+    """Checking overlap of two given list.
+
+    Function is used for checking if a list of variables is present in
+    the column names of a given dataframe (of quantities for data analysis)
+
+    Input
+    -----
+        columns: list of strings
+            given extensive list (usually column names of a pd.DataFrame)
+        variables: list of strings
+            list of names to extract/check overlap with strings in list 'column'
+        name_variables: str, default is 'variables'
+            name of type of variables given in list 'variables'
+
+    Output
+    ------
+        intersection: list
+            list of strings present in both lists 'columns' and 'variables'
+
+    """
+    if isinstance(variables,list):
+        intersection = list(set(columns) & set(variables))
+        remainder = list(set(variables) - set(columns))
+        if len(intersection) == 0:
+            raise ValueError("No column names for '{}' identified in columns of dataframe.".format(name_variables))
+        elif len(intersection) < len(variables):
+            print("WARNING: not all column names for '{}' are found in dataframe.".format(name_variables))
+            print('----------------------------------------------------------------')
+            print("Columns used in analysis:", intersection)
+            print("Column names not identified in data:", remainder)
+            print('________________________________________________________________')
+    else:
+        raise ValueError("List of column names for '{}' empty or in wrong format.".format(name_variables))
+
+    return intersection
+
+
+def check_data_frame(data_frame):
     """Checking data on correct format.
 
     Input
     -----
-        data: pd.DataFrame
-            concentration values of quantities
+        data_frame: pd.DataFrame
+            quantities for data analysis given per sample
 
     Output
     ------
+        data: pd.DataFrame
+            copy of given dataframe with index set to sample name
         cols: list
-        List of column names
+            List of column names
     """
-    if isinstance(data, pd.DataFrame):
-        cols = data.columns.to_list()
-    # elif isinstance(data, pd.Series):
-    #     cols = [data.name]
-    else:
+    if not isinstance(data_frame, pd.DataFrame):
         raise ValueError("Calculation not possible with given data. \
                           Data has to be a panda-DataFrame or Series \
-                          but is given as type {}".format(type(data)))
+                          but is given as type {}".format(type(data_frame)))
+    else:
+        data = data_frame.copy()
+        cols = data.columns.to_list()
+        if name_sample in data.columns:
+            data.set_index(name_sample,inplace = True)
+            cols.remove(name_sample)
 
-    return cols
+    return data, cols

--- a/mibipret/analysis/reduction/ordination.py
+++ b/mibipret/analysis/reduction/ordination.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 16 13:59:36 2024
+
+@author: alraune
+"""
+
+import numpy as np
+import pandas as pd
+from sklearn import decomposition
+# import skbio.stats.ordination as sciord
+
+from mibipret.data.names import name_sample
+
+def pca(data, 
+        select_columns = False,
+        n_comp = 2,
+        verbose = False,
+        ):
+
+    '''
+    Function that performs Principal Component Analysis.
+    
+    Makes use of routine sklearn.decomposition.PCA on the input data and gives 
+    the site scores and loadings.
+    
+    Principal component analysis (PCA) is a linear dimensionality reduction 
+    technique with applications in exploratory data analysis, visualization 
+    and data preprocessing. The data is linearly transformed onto a new 
+    coordinate system such that the directions (principal components) capturing 
+    the largest variation in the data can be easily identified. 
+
+    Parameters
+    ----------
+        data : pd.dataframe
+            Tabular data containing quantities to be evaluated with standard
+            column names and rows of sample data.
+        n_comp : int, default is 2
+            Number of components to report
+        select_columns: Boolean or list of strings; default False
+           list with column names to select from dataframe for analysis             
+        verbose : Boolean, The default is False.
+           Set to True to get messages in the Console about the status of the run code. 
+
+    Returns
+    -------
+        results : Dictionary
+            containing the scores and loadings of the PCA, 
+            the percentage of the variation explained by the first principal components
+            and the correlation coefficient between the first two PCs
+    '''
+
+    if verbose:
+        print('==============================================================')
+        print(" Running function 'pca()' on data")
+        print('==============================================================')
+
+    cols= check_data(data)       
+    data_pca = data.copy()
+    
+    if name_sample in cols:
+        data_pca.set_index(name_sample,inplace = True)
+        cols.remove(name_sample)
+    
+    if isinstance(select_columns,list):
+        intersection = list(set(cols) & set(select_columns))
+        remainder = list(set(select_columns) - set(cols))
+        if len(intersection) == 0:
+            raise ValueError("No specified column names identified in data.")     
+        elif len(intersection) < len(select_columns):
+            print("WARNING: not all specified column names are found in data.")
+            print('----------------------------------------------------------------')
+            print("Columns used in analysis:", intersection)
+            print("Column names not identified in data:", remainder)
+            print('________________________________________________________________')
+
+        # data_pca = data_pca.get(intersection)
+        data_pca = data_pca[intersection]
+
+    # heads = data_pca.columns.to_list()
+    # wells = list(data_pca.index)
+    
+    # Checking if the dimensions of the dataframe allow for PCA
+    if data_pca.shape[0] < data_pca.shape[1]:
+        raise Exception("PCA not possible with more variables than samples.")
+
+    try:
+        # Using scikit.decomposoition.PCA with an amount of components equal to the amount of variables, then getting the loadings, scores and explained variance ratio.
+        pca = decomposition.PCA(n_components=len(data_pca.columns)) 
+        pca.fit(data_pca)
+        loadings = pca.components_.T
+        PCAscores = pca.transform(data_pca)
+        variances = pca.explained_variance_ratio_
+    except(ValueError):
+        raise ValueError("Not all column values are numeric values. Consider standardizing data first.")
+    
+    # Taking the first two PC for plotting
+    loadings = loadings[:, 0:n_comp]
+    scores = PCAscores[:, 0:n_comp]
+    percent_explained = np.around(100*variances/np.sum(variances), decimals=2)
+    coef = np.corrcoef(scores[:,0], scores[:,1])[0,1]
+    
+    if verbose:
+        print("Information about the succes of the PCA:")
+        print('----------------------------------------------------------------')        
+        for i in range(len(percent_explained)):
+            print('Principle component {} explains {} \% of the total variance.'.format(i,percent_explained[i]))
+        print('\nThe correlation coefficient between PC1 and PC2 is {}.'.format(coef))
+        print('----------------------------------------------------------------')
+    
+    results = {"method": 'pca',
+               "loadings": loadings, 
+               "scores": scores, 
+               "percent_explained": percent_explained,
+               "corr_PC1_PC2": coef,
+               }
+
+    # if sample_names is True:
+    #     names = data[name_sample]
+
+    # sample_names = False,
+    # heads = data_pca.columns.to_list()
+    # wells = list(data_pca.index)
+    # names = {"heads": heads, "Species_head": Species_head, "Environment_head": Environment_head, "wells": wells}
+    
+    return results
+
+def check_data(data):
+    """Checking data on correct format.
+
+    Input
+    -----
+        data: pd.DataFrame
+            concentration values of quantities
+
+    Output
+    ------
+        cols: list
+        List of column names
+    """
+    if isinstance(data, pd.DataFrame):
+        cols = data.columns.to_list()
+    # elif isinstance(data, pd.Series):
+    #     cols = [data.name]
+    else:
+        raise ValueError("Calculation not possible with given data. \
+                          Data has to be a panda-DataFrame or Series \
+                          but is given as type {}".format(type(data)))
+
+    return cols

--- a/mibipret/visualize/activity.py
+++ b/mibipret/visualize/activity.py
@@ -66,6 +66,7 @@ def activity(
     settings = copy.copy(DEF_settings)
     settings.update(**kwargs)
 
+    ### ---------------------------------------------------------------------------
     ### Handling of input data
     if isinstance(data, pd.DataFrame):
         meta_count = data[name_metabolites_variety].values
@@ -95,6 +96,8 @@ def activity(
     if len(tot_cont) <= 1:
         raise ValueError("Too little data for activity plot. At least two values per quantity required.")
 
+    ### ---------------------------------------------------------------------------
+    ### Creating Figure
     fig, ax = plt.subplots(figsize=settings['figsize'])
     ax.scatter(tot_cont,
                meta_count,
@@ -105,6 +108,7 @@ def activity(
                lw = settings['lw'],
                )
 
+    ### generate legend labels
     if "green" in well_color:
         ax.scatter([], [],
                    label="available",
@@ -130,6 +134,8 @@ def activity(
                    lw = settings['lw'],
                    )
 
+    ### ---------------------------------------------------------------------------
+    ### Adapt plot optics
     ax.set_xlabel(r"Concentration contaminants [$\mu$g/L]",fontsize=settings['textsize'])
     ax.set_ylabel("Metabolite variety", fontsize=settings['textsize'])
     ax.grid()
@@ -139,6 +145,8 @@ def activity(
     plt.legend(title = 'Electron acceptors:',loc =settings['loc'], fontsize=settings['textsize'] )
     fig.tight_layout()
 
+    ### ---------------------------------------------------------------------------
+    ### Save figure to file if file path provided
     if save_fig is not False:
         try:
             plt.savefig(save_fig)

--- a/mibipret/visualize/ordination_plot.py
+++ b/mibipret/visualize/ordination_plot.py
@@ -1,233 +1,253 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-Created on Tue Jul 16 14:06:50 2024
+"""Ordination plot.
 
-@author: alraune
+@author: Alraune Zech
 """
 
-import numpy as np
-import pandas as pd
 import copy
 import matplotlib.pyplot as plt
-plt.close('all')
-
-from ordination import pca #, cca, rda
+import numpy as np
 
 DEF_settings = dict(
     figsize = [3.75,3.75],
     dpi = 300,
-    textsize = 10,
-    arrow_color_head = 'blue',
-    arrow_color = 'red',
-    arrow_width = 0.002, 
-    arrowhead_width = 0.02, 
-    arrowhead_length = 0.02,     
+    label_fontsize = 8,
+    loading_fontsize = 8,
+    score_fontsize = 6,
+    arrow_color_independent = 'blue',
+    arrow_color_dependent = 'red',
+    fontstyle_independent = 'normal',
+    fontstyle_dependent = 'italic',
+    weight_independent = "bold",
+    weight_dependent = 'normal',
+    arrow_width = 0.002,
+    arrow_head_width = 0.02,
+    arrow_head_length = 0.02,
     score_color = 'gray',
     score_edgecolor = 'gray',
     score_facecolor = 'none',
     score_marker = 'o',
-    score_marker_size = 45,       
-    # adjust_text = True, 
-    axis_ranges = False,
+    score_marker_size = 45,
     )
 
-data = pd.read_csv('data_pcs.csv')
+def ordination_plot(ordination_output,
+                    plot_loadings = True,
+                    plot_scores = True,
+                    rescale_loadings_scores = False,
+                    adjust_text = True,
+                    scale_focus = "loadings",
+                    axis_ranges = False,
+                    save_fig=False,
+                    **kwargs,
+                    ):
+    """Function creating ordination plot.
 
-# pca_results = pca(data,verbose = True)
-pca_output = pca(data,
-                  # select_columns = ['nitrate','pH','nitrite','sulfate','Redox'],
-                  # n_comp=2,
-                  verbose = True)
+    Based on ordination analysis providing ordination loadings and scores.
 
-print(pca_output)
-data = pca_output 
-# mibipret.visualize.ordination(data=pca_output)
+    Input
+    -----
+        ordination_output : Dictionary
+            contains ordination results:
+                - as numpy arrays; ordination loading and scores
+                - names of the samples and the Environmental and Species variables
+                - method : String (pca, cca, rda) The ordination method used in the analysis.
+        plot_loadings : Boolean; default is True
+            flag to plot the ordination loadings
+        plot_scores : Boolean; default is True
+            flag to plot the ordiantion scores
+        rescale_loadings_scores : Boolean; default is False
+            flag to rescale loadings and scores to have a loading close to 1
+        adjust_text : Boolean, default is True
+            flag to perform automized adjustment of text labes of loadings and scores to avoid overlap
+        scale_focus : String, default is "loadings"
+            flag to specify if scaling focusses on either 'loadings' or 'scores' or 'none'.
+        axis_ranges : Boolean or list/array of 4 values, default is False,
+            if array or list it gives fixed x and y axis dimensions [x_min, x_maxm y_min, y_max]
+        save_fig: Boolean or string, optional, default is False.
+            Flag to save figure to file with name provided as string.
+        **kwargs: dict
+            dictionary with plot settings (e.g. fonts, arrow specifics, etc)
 
-# def ordination_plot(data,
-#                     plot_loadings = True, 
-#                     plot_scores = True, 
-#                     rescale_loadings_scores = False, 
-#                     scale_focus = "Loadings", 
-#                     save_fig=False,
-#                     **kwargs,
-#                     ):
-#     """Function creating ordination plot.
+    Output
+    ------
+        fig : Figure object
+            Figure object of created activity plot.
+        ax :  Axes object
+            Axes object of created activity plot.
+    """
+    settings = copy.copy(DEF_settings)
+    settings.update(**kwargs)
 
-#         Based on ordination analysis providing ordination loadings and scores.
+    ### ---------------------------------------------------------------------------
+    ### check on completeness of input ordination_output
 
-#     """            
+    if not isinstance(ordination_output,dict):
+        raise TypeError("Input data must be given as dictionary with standard output of ordination methods.")
 
-# Adjust_text = True, 
-
-save_fig = 'save.png'
-plot_loadings = True
-plot_scores = True    #False #
-rescale_loadings_scores = False #True 
-scale_focus = "loadings"
-
-settings = copy.copy(DEF_settings)
-# settings.update(**kwargs)
-
-### ---------------------------------------------------------------------------
-### check on completeness of input data
-if not isinstance(data,dict):
-    raise ValueError()
-elif "loadings" not in data.keys():
-    raise ValueError()
-elif "scores" not in data.keys():
-    raise ValueError()
-
-loadings = data["loadings"]
-scores = data["scores"]
-
-### ---------------------------------------------------------------------------
-### Rescale data given plot specifics
-
-# Determing the largest values in the PCA scores for axis dimensions.
-max_load = np.max(np.abs(loadings))
-if len(scores):
-    max_score = np.max(np.abs(scores))
-else:
-    max_score = 1    
-
-# Rescale scores and loadings to range between -1 and 1
-if rescale_loadings_scores:
-    if max_load >= 1:
-        loadings = loadings / max_load
-        max_load = np.max(np.abs(loadings))
-    if max_score >= 1:
-        scores = scores / max_score
-        max_score = np.max(np.abs(scores))
-
-if settings['axis_ranges'] is not False:
-    # Takes the given axis dimensions for both ordination axes
-    x_lim_neg,x_lim_pos,y_lim_neg,y_lim_pos = settings['axis_ranges']
-else:
-    # Adjusts axis dimensions for both ordination axes to data
-    if plot_scores and plot_loadings:
-        # When plotting both scores and loadings, scores or loadings are scaled depending on the extent of the other. Depends on the input of Scale_focus.
-        if scale_focus == "loadings":
-            scores = scores * max_load
-        elif scale_focus == "scores":
-            loadings = loadings * max_score
-        full_coords = np.append(loadings, scores, axis=0)
-    elif plot_loadings:
-        full_coords = loadings
+    if "loadings_independent" not in ordination_output.keys():
+        raise KeyError("Input dictionary does not contain data on loadings ('loadings_independent')")
     else:
-        full_coords = scores
+        loadings_independent = ordination_output["loadings_independent"]
+        names_independent = ordination_output["names_independent"]
+        if len(loadings_independent) == 0:
+            loadings_independent = np.array([[],[]]).T
 
-    x_lim_pos = 0.11*np.ceil(np.max(full_coords[:,0])*10)
-    y_lim_pos = 0.11*np.ceil(np.max(full_coords[:,1])*10)
-    x_lim_neg = 0.11*np.floor(np.min(full_coords[:,0])*10)
-    y_lim_neg = 0.11*np.floor(np.min(full_coords[:,1])*10)
+    if "scores" not in ordination_output.keys():
+        raise KeyError("Input dictionary does not contain data on scores ('scores')")
+    else:
+        scores = ordination_output["scores"]
 
-### ---------------------------------------------------------------------------
-### Create Figure, finally!    
-plt.figure(figsize = settings['figsize'],dpi=settings['dpi'])
+    if "sample_index" not in ordination_output.keys():
+        sample_index = np.arange(scores.shape[0])
+    else:
+        sample_index = ordination_output["sample_index"]
 
-# Plotting the ordination scores by iterating over every coordinate in the scores array, if the Plot_scores parameter is set to true.
-if plot_scores:
-    for i, (x, y) in enumerate(scores):
-        plt.scatter(x, y, 
-                    color=settings['score_color'], 
-                    marker = settings['marker'],
-                    s = settings['s'],
-                    facecolor=settings['facecolor'], 
-                    edgecolor=settings['edgecolor'],
-                    zorder = 10,
-                    # **settings,
-                    )
-        # Plotting the name of the scores and storing it in a list for the purpose of adjusting the position later
-        # tex = plt.text(x, y, wells[i], color='black', fontsize = settings['textsize'])
-        # texts.append(tex)
+    if "loadings_dependent" in ordination_output.keys():
+        loadings_dependent = ordination_output["loadings_dependent"]
+        names_dependent = ordination_output["names_dependent"]
+        if len(loadings_dependent) == 0:
+            loadings_dependent = np.array([[],[]]).T
+        loadings = np.append(loadings_independent, loadings_dependent, axis=0)
+    else:
+        loadings = loadings_independent
 
-# Plotting the ordination loadings by iterating over every coordinate in the loadings array, if the Plot_scores parameter is set to true.
-if plot_loadings:
-    for i, (x, y) in enumerate(loadings):
-        # Plots Environmental and Species variables with different colours and text formatting.
-        # if heads[i] in Environment_head:
-        #     plt.arrow(0, 0, x, y, 
-        #               color='blue', 
-        #               width = Arrow_width, 
-        #               head_length = Arrowhead_length, 
-        #               head_width = Arrowhead_width
-        #               )
-        #     #Plotting the name of the loading and storing it in a list for the purpose of adjusting the position later
-        #     tex = plt.text(x, y, heads[i], 
-        #                    color='black', 
-        #                    fontstyle='italic', 
-        #                    fontsize = Loadingtext_font
-        #                    )
-        #     c_arrow = settings['arrow_color_head']
-        # else:
-        #     c_arrow = settings['arrow_color']
-        #     #Plotting the name of the loading and storing it in a list for the purpose of adjusting the position later
-        #     tex = plt.text(x, y, heads[i], 
-        #                    color='black', 
-        #                    weight="bold", 
-        #                    fontsize = Loadingtext_font
-        #                    )
-        # texts.append(tex)
-        c_arrow = settings['arrow_color_head']
-        plt.arrow(0, 0, x, y, 
-                  color=c_arrow, 
-                  width = settings['arrow_width'], 
-                  head_length = settings['arrow_head_length'], 
-                  head_width = settings['arrow_head_width'],
-                  zorder = 9,
-                  )
+    ### ---------------------------------------------------------------------------
+    ### Rescale ordination_output given plot specifics
 
-# Plotting lines that indicate the origin
-plt.plot([-1, 1], [0, 0], color='grey', linewidth=0.75, linestyle='--')
-plt.plot([0, 0], [-1, 1], color='grey', linewidth=0.75, linestyle='--')
- 
-### ---------------------------------------------------------------------------
-### Adapt plot optics
-       
-# Setting the x and y axis limits with the previously determined values
-plt.xlim(x_lim_neg, x_lim_pos)
-plt.ylim(y_lim_neg, y_lim_pos)
+    # Determing the largest values in the PCA scores.
+    max_load = np.max(np.abs(loadings))
+    max_score = np.max(np.abs(scores))
 
-# Plots the axis title with the percentage of variation explained if the method was PCA
-if data["method"]=='pca':
-    percent_explained = data["percent_explained"]
-    plt.xlabel('PC1 (%s%%)' % percent_explained[0], fontsize = settings['textsize'])
-    plt.ylabel('PC2 (%s%%)' % percent_explained[1], fontsize = settings['textsize'])
-# Otherwise just plots a general axis title.
-else:
-    plt.xlabel('ordination axis 1', fontsize = settings['textsize'])
-    plt.ylabel('ordination axis 2', fontsize = settings['textsize'])
+    if max_load > 1 or rescale_loadings_scores:
+        # loadings = loadings / (max_load*1.05)
+        loadings = loadings / (max_load)
+    if max_score > 1 or rescale_loadings_scores:
+        # scores = scores / (max_score*1.05)
+        scores = scores / (max_score)
 
+    if axis_ranges is not False:
+        # Takes the given axis dimensions for both ordination axes
+        x_lim_neg,x_lim_pos,y_lim_neg,y_lim_pos = axis_ranges
+    else:
+        # Adjusts axis dimensions for both ordination axes to ordination_output
+        if plot_scores and plot_loadings:
+            # When plotting both scores and loadings, scores or loadings are scaled
+            # depending on the extent of the other. Depends on the input of Scale_focus.
+            if scale_focus == "loadings":
+                scores = scores * np.max(np.abs(loadings))
+            elif scale_focus == "scores":
+                loadings = loadings *  np.max(np.abs(scores))
+            full_coords = np.append(loadings, scores, axis=0)
+        elif plot_loadings:
+            full_coords = loadings
+        else:
+            full_coords = scores
 
-# Changing the axis ticks and removing all but the first and last tick labels
-# ax = plt.gca()
-# x_ticks = np.around(ax.get_xticks(), decimals=1)
-# y_ticks = np.around(ax.get_yticks(), decimals=1)
-# x_tick_labels = [str(x_ticks[0])] + [''] * (len(x_ticks) - 2) + [str(x_ticks[-1])]
-# y_tick_labels = [str(y_ticks[0])] + [''] * (len(y_ticks) - 2) + [str(y_ticks[-1])]
-# ax.set_xticklabels(x_tick_labels, fontsize = settings['textsize'])
-# ax.set_yticklabels(y_tick_labels, fontsize = settings['textsize'])
-plt.tick_params(axis="both",which="major",labelsize=settings['textsize']-2)
+        x_lim_pos = 0.11*np.ceil(np.max(full_coords[:,0])*10)
+        y_lim_pos = 0.11*np.ceil(np.max(full_coords[:,1])*10)
+        x_lim_neg = 0.11*np.floor(np.min(full_coords[:,0])*10)
+        y_lim_neg = 0.11*np.floor(np.min(full_coords[:,1])*10)
 
-# if settings['adjust_text']:
-#     try:
-#         from adjustText import adjust_text
-#         import warnings
-#         #adjust_text gives an irrelevant warning for the purpose of this scipt. The statement below will make sure that warning does not show up.
-#         warnings.filterwarnings("ignore")
-#         adjust_text(texts)
-#     except() 
+    ### ---------------------------------------------------------------------------
+    ### Create Figure, finally!
+    fig, ax = plt.subplots(figsize=settings['figsize'],
+                           dpi=settings['dpi'],
+                           )
+    texts = []
 
-### ---------------------------------------------------------------------------
-### Save figure to file if file path provided
+    # Plotting the ordination scores by iterating over every coordinate
+    # in the scores array, if the Plot_scores parameter is set to true.
+    if plot_scores:
+        for i, (x, y) in enumerate(scores):
+            plt.scatter(x, y,
+                        color=settings['score_color'],
+                        marker = settings['score_marker'],
+                        s = settings['score_marker_size'],
+                        facecolor=settings['score_facecolor'],
+                        edgecolor=settings['score_edgecolor'],
+                        zorder = 7,
+                        )
+            # Plotting the name of the scores and storing it in a list for the purpose of adjusting the position later
+            tex = plt.text(x, y, sample_index[i], color='black', fontsize = settings['score_fontsize'],zorder = 9)
+            texts.append(tex)
 
-plt.tight_layout()
-if save_fig is not False:
-    try:
-        plt.savefig(save_fig)
-        print("Save Figure to file:\n", save_fig)
-    except OSError:
-        print("WARNING: Figure could not be saved. Check provided file path and name: {}".format(save_fig))
+    if plot_loadings:
+        # Plots independent (=environmental) and dependent (=species) variables
+        # with different colours and text formatting.
+        for i, (x, y) in enumerate(loadings_independent):
+            plt.arrow(0, 0, x, y,
+                      color = settings['arrow_color_independent'],
+                      width = settings['arrow_width'],
+                      head_length = settings['arrow_head_length'],
+                      head_width = settings['arrow_head_width'],
+                      zorder = 10,
+                      )
+            #Plotting the name of the loading
+            tex = plt.text(x, y, names_independent[i],
+                            color='black',
+                            fontstyle = settings['fontstyle_independent'],
+                            weight = settings['weight_independent'],
+                            fontsize = settings['loading_fontsize'],
+                            zorder = 11,
+                            )
+            texts.append(tex)
+        if "loadings_dependent" in ordination_output.keys():
+            for i, (x, y) in enumerate(loadings_dependent):
+                plt.arrow(0, 0, x, y,
+                          color=settings['arrow_color_dependent'],
+                          width = settings['arrow_width'],
+                          head_length = settings['arrow_head_length'],
+                          head_width = settings['arrow_head_width'],
+                          zorder = 8,
+                          )
+                tex = plt.text(x, y, names_dependent[i],
+                                color='black',
+                                fontstyle = settings['fontstyle_dependent'],
+                                weight = settings['weight_dependent'],
+                                fontsize = settings['loading_fontsize'],
+                                zorder = 9,
+                                )
+                # and storing it in a list for the purpose of adjusting the position later
+                texts.append(tex)
 
-# return fig, ax
+    ### ---------------------------------------------------------------------------
+    ### Adapt plot optics
+
+    # Plotting lines that indicate the origin
+    plt.plot([-1, 1], [0, 0], color='grey', linewidth=0.75, linestyle='--')
+    plt.plot([0, 0], [-1, 1], color='grey', linewidth=0.75, linestyle='--')
+
+    # Setting the x and y axis limits with the previously determined values
+    plt.xlim(x_lim_neg, x_lim_pos)
+    plt.ylim(y_lim_neg, y_lim_pos)
+    plt.tick_params(axis="both",which="major",labelsize=settings['label_fontsize'])
+
+    if ordination_output["method"]=='pca':
+        percent_explained = ordination_output["percent_explained"]
+        plt.xlabel('PC1 ({:.1f}%)'.format(percent_explained[0]), fontsize = settings['label_fontsize'])
+        plt.ylabel('PC2 ({:.1f}%)'.format(percent_explained[1]), fontsize = settings['label_fontsize'])
+    else:
+        plt.xlabel('ordination axis 1', fontsize = settings['label_fontsize'])
+        plt.ylabel('ordination axis 2', fontsize = settings['label_fontsize'])
+
+    if adjust_text:
+        try:
+            from adjustText import adjust_text
+            adjust_text(texts)
+        except ImportError:
+            print("WARNING: packages 'adjustText' not installed.")
+            print(" For making text adjustment, install package 'adjustText'.")
+
+    ### ---------------------------------------------------------------------------
+    ### Save figure to file if file path provided
+
+    plt.tight_layout()
+    if save_fig is not False:
+        try:
+            plt.savefig(save_fig)
+            print("Figure saved to file:\n", save_fig)
+        except OSError:
+            print("WARNING: Figure could not be saved. Check provided file path and name: {}".format(save_fig))
+
+    return fig, ax

--- a/mibipret/visualize/ordination_plot.py
+++ b/mibipret/visualize/ordination_plot.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 16 14:06:50 2024
+
+@author: alraune
+"""
+
+import numpy as np
+import pandas as pd
+import copy
+import matplotlib.pyplot as plt
+plt.close('all')
+
+from ordination import pca #, cca, rda
+
+DEF_settings = dict(
+    figsize = [3.75,3.75],
+    dpi = 300,
+    textsize = 10,
+    arrow_color_head = 'blue',
+    arrow_color = 'red',
+    arrow_width = 0.002, 
+    arrowhead_width = 0.02, 
+    arrowhead_length = 0.02,     
+    score_color = 'gray',
+    score_edgecolor = 'gray',
+    score_facecolor = 'none',
+    score_marker = 'o',
+    score_marker_size = 45,       
+    # adjust_text = True, 
+    axis_ranges = False,
+    )
+
+data = pd.read_csv('data_pcs.csv')
+
+# pca_results = pca(data,verbose = True)
+pca_output = pca(data,
+                  # select_columns = ['nitrate','pH','nitrite','sulfate','Redox'],
+                  # n_comp=2,
+                  verbose = True)
+
+print(pca_output)
+data = pca_output 
+# mibipret.visualize.ordination(data=pca_output)
+
+# def ordination_plot(data,
+#                     plot_loadings = True, 
+#                     plot_scores = True, 
+#                     rescale_loadings_scores = False, 
+#                     scale_focus = "Loadings", 
+#                     save_fig=False,
+#                     **kwargs,
+#                     ):
+#     """Function creating ordination plot.
+
+#         Based on ordination analysis providing ordination loadings and scores.
+
+#     """            
+
+# Adjust_text = True, 
+
+save_fig = 'save.png'
+plot_loadings = True
+plot_scores = True    #False #
+rescale_loadings_scores = False #True 
+scale_focus = "loadings"
+
+settings = copy.copy(DEF_settings)
+# settings.update(**kwargs)
+
+### ---------------------------------------------------------------------------
+### check on completeness of input data
+if not isinstance(data,dict):
+    raise ValueError()
+elif "loadings" not in data.keys():
+    raise ValueError()
+elif "scores" not in data.keys():
+    raise ValueError()
+
+loadings = data["loadings"]
+scores = data["scores"]
+
+### ---------------------------------------------------------------------------
+### Rescale data given plot specifics
+
+# Determing the largest values in the PCA scores for axis dimensions.
+max_load = np.max(np.abs(loadings))
+if len(scores):
+    max_score = np.max(np.abs(scores))
+else:
+    max_score = 1    
+
+# Rescale scores and loadings to range between -1 and 1
+if rescale_loadings_scores:
+    if max_load >= 1:
+        loadings = loadings / max_load
+        max_load = np.max(np.abs(loadings))
+    if max_score >= 1:
+        scores = scores / max_score
+        max_score = np.max(np.abs(scores))
+
+if settings['axis_ranges'] is not False:
+    # Takes the given axis dimensions for both ordination axes
+    x_lim_neg,x_lim_pos,y_lim_neg,y_lim_pos = settings['axis_ranges']
+else:
+    # Adjusts axis dimensions for both ordination axes to data
+    if plot_scores and plot_loadings:
+        # When plotting both scores and loadings, scores or loadings are scaled depending on the extent of the other. Depends on the input of Scale_focus.
+        if scale_focus == "loadings":
+            scores = scores * max_load
+        elif scale_focus == "scores":
+            loadings = loadings * max_score
+        full_coords = np.append(loadings, scores, axis=0)
+    elif plot_loadings:
+        full_coords = loadings
+    else:
+        full_coords = scores
+
+    x_lim_pos = 0.11*np.ceil(np.max(full_coords[:,0])*10)
+    y_lim_pos = 0.11*np.ceil(np.max(full_coords[:,1])*10)
+    x_lim_neg = 0.11*np.floor(np.min(full_coords[:,0])*10)
+    y_lim_neg = 0.11*np.floor(np.min(full_coords[:,1])*10)
+
+### ---------------------------------------------------------------------------
+### Create Figure, finally!    
+plt.figure(figsize = settings['figsize'],dpi=settings['dpi'])
+
+# Plotting the ordination scores by iterating over every coordinate in the scores array, if the Plot_scores parameter is set to true.
+if plot_scores:
+    for i, (x, y) in enumerate(scores):
+        plt.scatter(x, y, 
+                    color=settings['score_color'], 
+                    marker = settings['marker'],
+                    s = settings['s'],
+                    facecolor=settings['facecolor'], 
+                    edgecolor=settings['edgecolor'],
+                    zorder = 10,
+                    # **settings,
+                    )
+        # Plotting the name of the scores and storing it in a list for the purpose of adjusting the position later
+        # tex = plt.text(x, y, wells[i], color='black', fontsize = settings['textsize'])
+        # texts.append(tex)
+
+# Plotting the ordination loadings by iterating over every coordinate in the loadings array, if the Plot_scores parameter is set to true.
+if plot_loadings:
+    for i, (x, y) in enumerate(loadings):
+        # Plots Environmental and Species variables with different colours and text formatting.
+        # if heads[i] in Environment_head:
+        #     plt.arrow(0, 0, x, y, 
+        #               color='blue', 
+        #               width = Arrow_width, 
+        #               head_length = Arrowhead_length, 
+        #               head_width = Arrowhead_width
+        #               )
+        #     #Plotting the name of the loading and storing it in a list for the purpose of adjusting the position later
+        #     tex = plt.text(x, y, heads[i], 
+        #                    color='black', 
+        #                    fontstyle='italic', 
+        #                    fontsize = Loadingtext_font
+        #                    )
+        #     c_arrow = settings['arrow_color_head']
+        # else:
+        #     c_arrow = settings['arrow_color']
+        #     #Plotting the name of the loading and storing it in a list for the purpose of adjusting the position later
+        #     tex = plt.text(x, y, heads[i], 
+        #                    color='black', 
+        #                    weight="bold", 
+        #                    fontsize = Loadingtext_font
+        #                    )
+        # texts.append(tex)
+        c_arrow = settings['arrow_color_head']
+        plt.arrow(0, 0, x, y, 
+                  color=c_arrow, 
+                  width = settings['arrow_width'], 
+                  head_length = settings['arrow_head_length'], 
+                  head_width = settings['arrow_head_width'],
+                  zorder = 9,
+                  )
+
+# Plotting lines that indicate the origin
+plt.plot([-1, 1], [0, 0], color='grey', linewidth=0.75, linestyle='--')
+plt.plot([0, 0], [-1, 1], color='grey', linewidth=0.75, linestyle='--')
+ 
+### ---------------------------------------------------------------------------
+### Adapt plot optics
+       
+# Setting the x and y axis limits with the previously determined values
+plt.xlim(x_lim_neg, x_lim_pos)
+plt.ylim(y_lim_neg, y_lim_pos)
+
+# Plots the axis title with the percentage of variation explained if the method was PCA
+if data["method"]=='pca':
+    percent_explained = data["percent_explained"]
+    plt.xlabel('PC1 (%s%%)' % percent_explained[0], fontsize = settings['textsize'])
+    plt.ylabel('PC2 (%s%%)' % percent_explained[1], fontsize = settings['textsize'])
+# Otherwise just plots a general axis title.
+else:
+    plt.xlabel('ordination axis 1', fontsize = settings['textsize'])
+    plt.ylabel('ordination axis 2', fontsize = settings['textsize'])
+
+
+# Changing the axis ticks and removing all but the first and last tick labels
+# ax = plt.gca()
+# x_ticks = np.around(ax.get_xticks(), decimals=1)
+# y_ticks = np.around(ax.get_yticks(), decimals=1)
+# x_tick_labels = [str(x_ticks[0])] + [''] * (len(x_ticks) - 2) + [str(x_ticks[-1])]
+# y_tick_labels = [str(y_ticks[0])] + [''] * (len(y_ticks) - 2) + [str(y_ticks[-1])]
+# ax.set_xticklabels(x_tick_labels, fontsize = settings['textsize'])
+# ax.set_yticklabels(y_tick_labels, fontsize = settings['textsize'])
+plt.tick_params(axis="both",which="major",labelsize=settings['textsize']-2)
+
+# if settings['adjust_text']:
+#     try:
+#         from adjustText import adjust_text
+#         import warnings
+#         #adjust_text gives an irrelevant warning for the purpose of this scipt. The statement below will make sure that warning does not show up.
+#         warnings.filterwarnings("ignore")
+#         adjust_text(texts)
+#     except() 
+
+### ---------------------------------------------------------------------------
+### Save figure to file if file path provided
+
+plt.tight_layout()
+if save_fig is not False:
+    try:
+        plt.savefig(save_fig)
+        print("Save Figure to file:\n", save_fig)
+    except OSError:
+        print("WARNING: Figure could not be saved. Check provided file path and name: {}".format(save_fig))
+
+# return fig, ax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 	"pandas",
 	"openpyxl",
 	"matplotlib",
+	"adjustText",
 	"scikit-learn",
 	"scikit-bio",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 	"pandas",
 	"openpyxl",
 	"matplotlib",
-	"sklearn",
+	"scikit-learn",
 	"scikit-bio",
 ]
 description = "A collection of analytical and semi-semianalytical solutions for hydrogeological transport phenomena"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
 	"pandas",
 	"openpyxl",
 	"matplotlib",
+	"sklearn",
+	"scikit-bio",
 ]
 description = "A collection of analytical and semi-semianalytical solutions for hydrogeological transport phenomena"
 keywords = [

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -14,7 +14,7 @@ from mibipret.visualize.activity import activity
 
 
 class TestActivity:
-    """Class for testing data module of mibipret."""
+    """Class for testing activity plot of mibipret."""
 
     meta = [41,33,47,20,36]
     conc = [13132.,11695.,4101.,498.,2822]

--- a/tests/test_ordination.py
+++ b/tests/test_ordination.py
@@ -1,0 +1,369 @@
+"""Tests for the mibipret.analysis.reduction.ordination module.
+
+@author: Alraune Zech
+"""
+
+import numpy as np
+
+# import pandas as pd
+import pytest
+from mibipret.analysis.reduction.ordination import cca
+from mibipret.analysis.reduction.ordination import check_data_frame
+from mibipret.analysis.reduction.ordination import constrained_ordination
+from mibipret.analysis.reduction.ordination import extract_variables
+from mibipret.analysis.reduction.ordination import pca
+from mibipret.analysis.reduction.ordination import rda
+from mibipret.data.data import example_data
+
+
+class TestOrdination:
+    """Class for testing ordination module of mibipret."""
+
+    data = example_data(with_units = False)
+    cols = data.columns.to_list()
+    environment_00 = ['oxygen','nitrate', 'Sulfate']
+    environment_01 = ['nitrate', 'oxygen','sulfate']
+    environment_02 = ['nitrate', 'oxygen','sulfate', 'ironII']
+
+    species_01 = ['benzene', 'toluene']
+    species_02 = ['benzene', 'toluene','naphthalene']
+    # species_03 = ['benzene', 'toluene','benzoic_acid']
+    species_03 = ['benzene', 'toluene','Phenol']
+
+
+    # data_01 = example_data(data_type = 'set_env_cont',with_units = True)
+    # data_02 = example_data(data_type = 'contaminants',with_units = True)
+    # data_03 = example_data(data_type = 'setting',with_units = True)
+    # data_04 = example_data(data_type = 'environment',with_units = True)
+    # data_05 = example_data(data_type = 'metabolites',with_units = True)
+    # data_05 = example_data(data_type = 'metabolites',with_units = True)
+    # new_column = pd.Series(data = ['ug/L',27.0, 54.1, 38.8, 19.70], name = 'unknown_contaminant')
+
+    def test_check_data_frame_01(self):
+        """Testing routine check_data_frame().
+
+        Correct identification of data as dataframe returning dataframe with
+        modified indices (being sample names) and the list of column names
+        """
+        df, cols = check_data_frame(self.data)
+
+        assert np.all(self.cols[1:] == cols)
+
+    def test_check_data_frame_02(self):
+        """Testing routine check_data_frame().
+
+        Correct error message when data is not a pd.dataframe
+        """
+        with pytest.raises(ValueError):
+            check_data_frame(self.data.iloc[:,3])
+
+    def test_extract_variables_01(self):
+        """Testing routine extract_variables().
+
+        Correct identification overlap between the two provided lists
+        """
+        intersection = extract_variables(self.cols,self.environment_00)
+
+        assert np.all(set(intersection) == set(self.environment_00[:-1]))
+
+    def test_extract_variables_02(self,capsys):
+        """Testing routine extract_variables().
+
+        Testing Warning that not all variables in the variables list
+        are detected in columns list
+        """
+        extract_variables(self.cols,self.environment_00)
+        out,err=capsys.readouterr()
+
+        assert len(out)>0
+
+    def test_extract_variables_03(self):
+        """Testing routine extract_variables().
+
+        Correct error message when no overlap between list of variables
+        and columns list
+        """
+        with pytest.raises(ValueError):
+            extract_variables(self.cols,['Sulfate'])
+
+    def test_extract_variables_04(self):
+        """Testing routine extract_variables().
+
+        Correct error message when argument 'variables' is not a list
+        """
+        with pytest.raises(ValueError):
+            extract_variables(self.cols,np.array(self.environment_00))
+
+    def test_constrained_ordination_01(self):
+        """Testing routine constrained_ordination().
+
+        Check that routine provides results dictionary with entries in correct
+        shapes for standard ordination method 'cca'.
+        """
+        ordination_output = constrained_ordination(self.data,
+                                                    independent_variables = self.environment_02,
+                                                    dependent_variables = self.species_02,
+                                                    )
+
+        test = [ordination_output['method'] == 'cca',
+                ordination_output['loadings_independent'].shape == (4,2),
+                ordination_output['loadings_dependent'].shape == (3,2),
+                ordination_output['scores'].shape == (4,2),
+                len(ordination_output['names_independent']) == 4,
+                len(ordination_output['names_dependent']) == 3,
+                len(ordination_output['sample_index']) == 4
+                ]
+
+        assert np.all(test)
+
+    def test_constrained_ordination_02(self):
+        """Testing routine constrained_ordination().
+
+        Check that routine provides results dictionary with entries in correct
+        shapes for ordination method 'rda'.
+        """
+        ordination_output = constrained_ordination(self.data,
+                                                   method =  'rda',
+                                                    independent_variables = self.environment_02,
+                                                    dependent_variables = self.species_02,
+                                                    )
+
+        test = [ordination_output['method'] == 'rda',
+                ordination_output['loadings_independent'].shape == (4,2),
+                ordination_output['loadings_dependent'].shape == (3,2),
+                ordination_output['scores'].shape == (4,2),
+                len(ordination_output['names_independent']) == 4,
+                len(ordination_output['names_dependent']) == 3,
+                len(ordination_output['sample_index']) == 4
+                ]
+
+        assert np.all(test)
+
+    def test_constrained_ordination_03(self):
+        """Testing routine constrained_ordination().
+
+        Correct error message when number of samples is smaller then number
+        of variables.
+        """
+        method = 'cca'
+        data = self.data.drop(labels = 4).copy()
+        with pytest.raises(ValueError,
+            match="Ordination method {} not possible with more variables than samples.".format(method)):
+            constrained_ordination(data,
+                                   method = method,
+                                   independent_variables = self.environment_02,
+                                   dependent_variables = self.species_02,
+                                   )
+
+    def test_constrained_ordination_04(self):
+        """Testing routine constrained_ordination().
+
+        Correct error message when selected method is not implemented.
+        """
+        method = "test"
+        with pytest.raises(ValueError,match="Ordination method {} not a valid option.".format(method)):
+            constrained_ordination(self.data,
+                                   method = method,
+                                   independent_variables = self.environment_02,
+                                   dependent_variables = self.species_02,
+                                   )
+
+    def test_constrained_ordination_05(self):
+        """Testing routine constrained_ordination().
+
+        Correct error message when number of dependent variables is too small.
+        """
+        with pytest.raises(ValueError,match="Number of dependent variables too small."):
+            constrained_ordination(self.data,
+                                   independent_variables = self.environment_02,
+                                   dependent_variables = self.species_01,
+                                   )
+
+    def test_constrained_ordination_06(self):
+        """Testing routine constrained_ordination().
+
+        Correct error message when data is not in normalized form/i.e.
+        values in data-frame columns are not numerics.
+        """
+        with pytest.raises(TypeError,
+           match="Not all column values are numeric values. Consider standardizing data first."):
+            constrained_ordination(self.data,
+                                   independent_variables = self.environment_02,
+                                   dependent_variables = self.species_03,
+                                   )
+
+    def test_rda_01(self):
+        """Testing routine rda().
+
+        Check that routine provides results dictionary with entries in correct
+        shapes.
+        """
+        ordination_output = rda(self.data,
+                                independent_variables = self.environment_02,
+                                dependent_variables = self.species_02,
+                                )
+
+        test = [ordination_output['method'] == 'rda',
+                ordination_output['loadings_independent'].shape == (4,2),
+                ordination_output['loadings_dependent'].shape == (3,2),
+                ordination_output['scores'].shape == (4,2),
+                len(ordination_output['names_independent']) == 4,
+                len(ordination_output['names_dependent']) == 3,
+                len(ordination_output['sample_index']) == 4
+                ]
+
+        assert np.all(test)
+
+    def test_rda_02(self,capsys):
+        """Testing routine rda().
+
+        Testing verbose flag.
+        """
+        rda(self.data,
+            independent_variables = self.environment_02,
+            dependent_variables = self.species_02,
+            verbose = True,
+            )
+        out,err=capsys.readouterr()
+
+        assert len(out)>0
+
+    def test_cca_01(self):
+        """Testing routine cca().
+
+        Check that routine provides results dictionary with entries in correct
+        shapes.
+        """
+        ordination_output = cca(self.data,
+                                independent_variables = self.environment_02,
+                                dependent_variables = self.species_02,
+                                )
+
+        test = [ordination_output['method'] == 'cca',
+                ordination_output['loadings_independent'].shape == (4,2),
+                ordination_output['loadings_dependent'].shape == (3,2),
+                ordination_output['scores'].shape == (4,2),
+                len(ordination_output['names_independent']) == 4,
+                len(ordination_output['names_dependent']) == 3,
+                len(ordination_output['sample_index']) == 4
+                ]
+
+        assert np.all(test)
+
+    def test_cca_02(self,capsys):
+        """Testing routine cca().
+
+        Testing verbose flag.
+        """
+        cca(self.data,
+            independent_variables = self.environment_02,
+            dependent_variables = self.species_02,
+            verbose = True,
+            )
+        out,err=capsys.readouterr()
+
+        assert len(out)>0
+
+    def test_pca_01(self):
+        """Testing routine pca().
+
+        Check that routine provides results dictionary with entries in correct
+        shapes.
+        """
+        ordination_output = pca(self.data,
+                                independent_variables = self.environment_01,
+                                )
+
+        test = [ordination_output['method'] == 'pca',
+                ordination_output['loadings_independent'].shape == (3,2),
+                ordination_output['loadings_dependent'].shape == (0,2),
+                ordination_output['scores'].shape == (4,2),
+                len(ordination_output['names_independent']) == 3,
+                len(ordination_output['names_dependent']) == 0,
+                len(ordination_output['sample_index']) == 4,
+                len(ordination_output['percent_explained']) == 3,
+                ordination_output['corr_PC1_PC2'] < 1e16,
+                ]
+
+        assert np.all(test)
+
+    def test_pca_02(self):
+        """Testing routine pca().
+
+        Check that routine provides results dictionary with entries in correct
+        shapes.
+        """
+        ordination_output = pca(self.data,
+                                dependent_variables = self.environment_01,
+                                )
+
+        test = [ordination_output['method'] == 'pca',
+                ordination_output['loadings_independent'].shape == (0,2),
+                ordination_output['loadings_dependent'].shape == (3,2),
+                ordination_output['scores'].shape == (4,2),
+                len(ordination_output['names_independent']) == 0,
+                len(ordination_output['names_dependent']) == 3,
+                len(ordination_output['sample_index']) == 4,
+                len(ordination_output['percent_explained']) == 3,
+                ordination_output['corr_PC1_PC2'] < 1e16,
+                ]
+
+        assert np.all(test)
+
+    def test_pca_03(self):
+        """Testing routine pca().
+
+        Check that routine provides results dictionary with entries in correct
+        shapes.
+        """
+        ordination_output = pca(self.data,
+                                independent_variables = self.environment_00,
+                                dependent_variables = self.species_01
+                                )
+
+        test = [ordination_output['method'] == 'pca',
+                ordination_output['loadings_independent'].shape == (2,2),
+                ordination_output['loadings_dependent'].shape == (2,2),
+                ordination_output['scores'].shape == (4,2),
+                len(ordination_output['names_independent']) == 2,
+                len(ordination_output['names_dependent']) == 2,
+                len(ordination_output['sample_index']) == 4,
+                len(ordination_output['percent_explained']) == 4,
+                ordination_output['corr_PC1_PC2'] < 1e15,
+                ]
+
+        assert np.all(test)
+
+    def test_pca_04(self):
+        """Testing routine pca().
+
+        Correct error message when number of samples is smaller then number
+        of variables.
+        """
+        with pytest.raises(ValueError,match="PCA not possible with more variables than samples."):
+            pca(self.data)
+
+    def test_pca_05(self):
+        """Testing routine pca().
+
+        Correct error message when data is not in normalized form/i.e.
+        values in data-frame columns are not numerics.
+        """
+        with pytest.raises(TypeError):
+            pca(self.data,
+                independent_variables = self.species_03,
+                )
+
+    def test_pca_06(self,capsys):
+        """Testing routine pca().
+
+        Testing verbose flag.
+        """
+        pca(self.data,
+            independent_variables = self.environment_02,
+            verbose = True,
+            )
+
+        out,err=capsys.readouterr()
+
+        assert len(out)>0

--- a/tests/test_ordination_plot.py
+++ b/tests/test_ordination_plot.py
@@ -1,0 +1,208 @@
+"""Tests for the ordination plots in mibipret.visualize module.
+
+@author: Alraune Zech
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from mibipret.visualize.ordination_plot import ordination_plot
+
+
+class TestOrdinationPlot:
+    """Class for testing ordination plots of mibipret."""
+
+    pca_output_01 = {
+        'method': 'pca',
+        'loadings_independent': np.array([[ 0.99999675, -0.002548  ],[-0.002548  , -0.99999675]]),
+        'loadings_dependent': [],
+        'names_independent': ['nitrate', 'oxygen'],
+        'names_dependent': [],
+        'scores': np.array([[ 4.44999192e+01, -8.83862725e-02],
+                            [-7.25012298e+01, -3.90267822e-01],
+                            [-7.44991849e+01,  4.14825590e-01],
+                            [ 1.02500495e+02,  6.38285042e-02]]),
+        'sample_index': ['2000-001', '2000-002', '2000-003', '2000-004'],
+        'percent_explained': np.array([100.,   0.]),
+        'corr_PC1_PC2': 2.587839267904467e-17
+        }
+
+    pca_output_02 = {
+        'method': 'pca',
+        'loadings_independent': [],
+        'loadings_dependent': np.array([[ 0.99999675, -0.002548  ],[-0.002548  , -0.99999675]]),
+        'names_dependent': ['nitrate', 'oxygen'],
+        'names_independent': [],
+        'scores': np.array([[ 4.44999192e+01, -8.83862725e-02],
+                            [-7.25012298e+01, -3.90267822e-01],
+                            [-7.44991849e+01,  4.14825590e-01],
+                            [ 1.02500495e+02,  6.38285042e-02]]),
+        'sample_index': ['2000-001', '2000-002', '2000-003', '2000-004'],
+        'percent_explained': np.array([100.,   0.]),
+        'corr_PC1_PC2': 2.587839267904467e-17
+        }
+
+    cca_output_01 = {
+        'method': 'cca',
+        'loadings_dependent': np.array([[-1.55077018e-01,  4.70442169e-04],
+               [ 3.55879473e-01, -3.72142498e-01],
+               [ 8.14223408e-01,  2.77055931e-03]]),
+        'loadings_independent': np.array([[ 0.73838654,  0.64988839],
+               [-0.83773509,  0.26245953],
+               [-0.54517573,  0.29924283],
+               [ 0.21397886,  0.67168236]]),
+        'names_independent': ['nitrate', 'oxygen', 'ironII', 'sulfate'],
+        'names_dependent': ['naphthalene', 'toluene', 'benzene'],
+        'scores': np.array([[-0.40987246,  1.32585167],
+               [-0.98163421,  0.24972093],
+               [ 0.16585265, -1.44306525],
+               [ 1.76833504,  0.67352295]]),
+        'sample_index': ['2000-001', '2000-002', '2000-003', '2000-004']
+        }
+
+    def test_ordination_plot_01(self):
+        """Testing routine activity().
+
+        Testing Error message that input data not in required data format.
+        """
+        with pytest.raises(TypeError):
+               # match="Input data must be given as dictionary with standard output of ordination methods."):
+            ordination_plot([1,2,3])
+
+    def test_ordination_plot_02(self):
+        """Testing routine activity().
+
+        Testing Error message that input dictionary does not contain all required data.
+        """
+        test ={key:value for key, value in self.pca_output_01.items() if key != 'loadings_independent'}
+
+        with pytest.raises(KeyError):
+               # match="Input dictionary does not contain data on loadings ('loadings_independent')\n"):
+            ordination_plot(test)
+
+    def test_ordination_plot_03(self):
+        """Testing routine activity().
+
+        Testing Error message that input dictionary does not contain all required data.
+        """
+        test ={key:value for key, value in self.pca_output_01.items() if key != 'scores'}
+
+        with pytest.raises(KeyError):
+               # match="Input dictionary does not contain data on scores ('scores')\n"):
+            ordination_plot(test)
+
+    def test_ordination_plot_04(self):
+        """Testing routine ordination_plot().
+
+        Testing that routine produces a plot when data is provided as dictionary
+        of pca data without dependent variables.
+        And standard plot settings.
+        """
+        fig, ax = ordination_plot(self.pca_output_01)
+
+        assert isinstance(fig,plt.Figure)
+
+    def test_ordination_plot_05(self):
+        """Testing routine ordination_plot().
+
+        Testing that routine produces a plot when data is provided as dictionary
+        of pca data without independent variables.
+        And standard plot settings.
+        """
+        fig, ax = ordination_plot(self.pca_output_02)
+
+        assert isinstance(fig,plt.Figure)
+
+    def test_ordination_plot_06(self):
+        """Testing routine ordination_plot().
+
+        Testing that routine produces a plot when data is provided as dictionary
+        of cca data with independent and dependent variables.
+        And standard plot settings.
+        """
+        fig, ax = ordination_plot(self.cca_output_01)
+
+        assert isinstance(fig,plt.Figure)
+
+
+    def test_ordination_plot_07(self):
+        """Testing routine ordination_plot().
+
+        Testing that routine produces a plot when data is provided as dictionary
+        of pca data with optional keys (sample index and dependent_variables).
+        And standard plot settings.
+        """
+        test ={key:value for key, value in self.pca_output_01.items() if key not
+               in ["sample_index",'loadings_dependent']}
+        fig, ax = ordination_plot(test)
+
+        assert isinstance(fig,plt.Figure)
+
+    def test_ordination_plot_08(self):
+        """Testing routine ordination_plot().
+
+        Testing keyword 'axis_ranges' and adjust_test.
+        """
+        fig, ax = ordination_plot(self.cca_output_01,
+                                  axis_ranges = [-2,2,-2,2],
+                                  adjust_text = False,
+                                  )
+
+        assert isinstance(fig,plt.Figure)
+
+    def test_ordination_plot_09(self):
+        """Testing routine ordination_plot().
+
+        Testing keyword 'plot_loadings' and adjust_test.
+        """
+        fig, ax = ordination_plot(self.cca_output_01,
+                                  plot_loadings = False,
+                                  )
+
+    def test_ordination_plot_10(self):
+        """Testing routine ordination_plot().
+
+        Testing keyword 'plot_scores'.
+        """
+        fig, ax = ordination_plot(self.cca_output_01,
+                                  plot_scores = False,
+                                  )
+
+        assert isinstance(fig,plt.Figure)
+
+    def test_ordination_plot_11(self):
+        """Testing routine ordination_plot().
+
+        Testing keyword 'rescale_loadings_scores'.
+        """
+        fig, ax = ordination_plot(self.cca_output_01,
+                                  rescale_loadings_scores = True,
+                                  )
+
+        assert isinstance(fig,plt.Figure)
+
+    def test_ordination_plot_12(self):
+        """Testing routine ordination_plot().
+
+        Testing keyword 'scale_focus'.
+        """
+        fig, ax = ordination_plot(self.cca_output_01,
+                                  plot_loadings = True,
+                                   plot_scores = True,
+                                   scale_focus = "scores",
+                                  )
+
+        assert isinstance(fig,plt.Figure)
+
+    def test_ordination_plot_13(self,capsys):
+        """Testing routine ordination_plot().
+
+        Testing keyword save_fig. Checks output of Warning that given file path
+        does not match for writing figure to file.
+        """
+        save_fig = '../dir_does_not_exist/file.png'
+        out_text = "WARNING: Figure could not be saved. Check provided file path and name: {}\n".format(save_fig)
+        ordination_plot(self.pca_output_01,save_fig = save_fig)
+        out,err=capsys.readouterr()
+
+        assert out==out_text


### PR DESCRIPTION
Adding routines to perform multi-variate statistics on sample data when provided as dataframe (following general setup of the package). Included methods:
- PCA (principal component analysis)
- CCA (canonical correspondence analysis)
- RDA (redundancy analysis)

Output is dictionary in a standard format which is input for the plotting routine "ordination_plot()" implemented in the package "visualize".

**Yet missing:**
- routines for data transformation
- support routines for selection of (independent/dependent) variables from standard data frame based on different type of sample data (settings, environmental data, contaminants, metabolites, DNA-related data)
